### PR TITLE
Document support for Quectel L80

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ the hardware setup.
 * [u-Blox NEO-6M]
 * [u-Blox NEO-7M]
 * [Uputronics u-blox MAX-M8C Pico]
+* [Quectel L80]
 
 If you have verified this application working with a module not listed here,
 please submit a PR adding it to the list.
@@ -78,3 +79,4 @@ of the repository.
 [u-Blox NEO-7M]: https://www.u-blox.com/en/product/neo-7-series
 [uFBT]: https://github.com/flipperdevices/flipperzero-ufbt
 [Uputronics u-blox MAX-M8C Pico]: https://store.uputronics.com/index.php?route=product/product&product_id=72
+[Quectel L80]: https://www.quectel.com/ProductDownload/L80.html


### PR DESCRIPTION
Reference: https://github.com/lekkas/flipper-zero-l80-gps/?tab=readme-ov-file#nmea-gps-flipper-app