### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ the hardware setup.
 * [Uputronics u-blox MAX-M8C Pico]
 * [Quectel L80]
 * [M10Q-5883]
+* NewHail GNSS Modul
 
 If you have verified this application working with a module not listed here,
 please submit a PR adding it to the list.


### PR DESCRIPTION
NewHail GNSS Modul

works 😃


Technical data:

Module-Chip  
 -  L76K 
 
GNSS antenna (supports GPS L1 C/A, BDS B1 and GLONASS L1 bands)  
 -  1584R-A  E